### PR TITLE
feat: add privacy features (prevent screenshots)

### DIFF
--- a/app/src/main/java/dev/mariinkys/openPillReminder/data/SettingsDataStore.kt
+++ b/app/src/main/java/dev/mariinkys/openPillReminder/data/SettingsDataStore.kt
@@ -34,6 +34,7 @@ object SettingsKeys {
     val THEME_MODE = stringPreferencesKey("theme_mode")
     val DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color")
     val SEED_COLOR = intPreferencesKey("seed_color")
+    val PREVENT_SCREENSHOTS = booleanPreferencesKey("prevent_screenshots")
 }
 
 class SettingsRepository(private val context: Context) {
@@ -60,7 +61,8 @@ class SettingsRepository(private val context: Context) {
             ),
             themeMode = ThemeMode.valueOf(prefs[SettingsKeys.THEME_MODE] ?: ThemeMode.SYSTEM.name),
             useDynamicColor = prefs[SettingsKeys.DYNAMIC_COLOR] ?: true,
-            seedColor = prefs[SettingsKeys.SEED_COLOR] ?: 0xFF6750A4.toInt()
+            seedColor = prefs[SettingsKeys.SEED_COLOR] ?: 0xFF6750A4.toInt(),
+            preventScreenshots = prefs[SettingsKeys.PREVENT_SCREENSHOTS] ?: false,
         )
     }
 
@@ -81,6 +83,7 @@ class SettingsRepository(private val context: Context) {
             prefs[SettingsKeys.THEME_MODE] = settings.themeMode.name
             prefs[SettingsKeys.DYNAMIC_COLOR] = settings.useDynamicColor
             prefs[SettingsKeys.SEED_COLOR] = settings.seedColor
+            prefs[SettingsKeys.PREVENT_SCREENSHOTS] = settings.preventScreenshots
         }
     }
 }

--- a/app/src/main/java/dev/mariinkys/openPillReminder/model/SettingsState.kt
+++ b/app/src/main/java/dev/mariinkys/openPillReminder/model/SettingsState.kt
@@ -19,7 +19,8 @@ data class SettingsState(
     val buyingReminderTime: LocalTime = LocalTime.of(8, 0),
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val useDynamicColor: Boolean = true,
-    val seedColor: Int = 0xFF6750A4.toInt() // Material Purple
+    val seedColor: Int = 0xFF6750A4.toInt(), // Material Purple
+    val preventScreenshots: Boolean = false,
 )
 
 enum class ThemeMode {

--- a/app/src/main/java/dev/mariinkys/openPillReminder/ui/AppLayout.kt
+++ b/app/src/main/java/dev/mariinkys/openPillReminder/ui/AppLayout.kt
@@ -1,5 +1,6 @@
 package dev.mariinkys.openPillReminder.ui
 
+import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -35,10 +36,31 @@ import dev.mariinkys.openPillReminder.ui.settings.SettingsScreen
 import dev.mariinkys.openPillReminder.ui.settings.SettingsViewModel
 import dev.mariinkys.openPillReminder.R
 import android.content.Context
+import android.view.WindowManager
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.flow.Flow
+
+
+@Composable
+private fun SecureWindow(enabled: Boolean) {
+    val context = LocalContext.current
+    DisposableEffect(enabled) {
+        val window = (context as? Activity)?.window
+        if (enabled) {
+            window?.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        } else {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        onDispose { }
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +74,8 @@ fun AppLayout(
     val settings by settingsViewModel.uiState.collectAsState()
     val isLoaded by settingsViewModel.isLoaded.collectAsState()
     val showPermissions by settingsViewModel.showPermissionRequest.collectAsState(initial = false)
+
+    SecureWindow(enabled = settings.preventScreenshots)
 
     val notificationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()

--- a/app/src/main/java/dev/mariinkys/openPillReminder/ui/settings/Screen.kt
+++ b/app/src/main/java/dev/mariinkys/openPillReminder/ui/settings/Screen.kt
@@ -229,6 +229,15 @@ fun SettingsScreen(
             }
         }
 
+        // PRIVACY
+        SettingsSection(title = stringResource(R.string.section_privacy)) {
+            SettingsSwitchRow(
+                label = stringResource(R.string.prevent_screenshots),
+                checked = settings.preventScreenshots,
+                onCheckedChange = { onSettingsChange(settings.copy(preventScreenshots = it)) },
+                description = stringResource(R.string.prevent_screenshots_desc)
+            )
+        }
 
         // APPEARANCE
         SettingsSection(title = stringResource(R.string.section_appearance)) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -33,6 +33,7 @@
     <string name="section_appearance">Aparença</string>
     <string name="section_backup">Còpia de seguretat</string>
     <string name="section_about">Sobre l\'App</string>
+    <string name="section_privacy">Privadesa</string>
 
     <!-- Labels and Fields -->
     <string name="your_name">El teu nom</string>
@@ -58,6 +59,10 @@
     <string name="five_days_before">5 dies abans</string>
     <string name="six_days_before">6 dies abans</string>
     <string name="seven_days_before">7 dies abans</string>
+
+    <!-- Privacy -->
+    <string name="prevent_screenshots">Evita les captures de pantalla</string>
+    <string name="prevent_screenshots_desc">Amaga l\'aplicació de la pantalla de recents i bloqueja les captures de pantalla</string>
 
     <!-- Backup -->
     <string name="create_backup">Crear còpia de seguretat</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -33,6 +33,7 @@
     <string name="section_appearance">Apariencia</string>
     <string name="section_backup">Copia de seguridad</string>
     <string name="section_about">Acerca de</string>
+    <string name="section_privacy">Privacidad</string>
 
     <!-- Labels and Fields -->
     <string name="your_name">Tu nombre</string>
@@ -58,6 +59,10 @@
     <string name="five_days_before">5 días antes</string>
     <string name="six_days_before">6 días antes</string>
     <string name="seven_days_before">7 días antes</string>
+
+    <!-- Privacy -->
+    <string name="prevent_screenshots">Evitar capturas de pantalla</string>
+    <string name="prevent_screenshots_desc">Oculta la aplicación de la pantalla de aplicaciones recientes y bloquea las capturas de pantalla</string>
 
     <!-- Backup -->
     <string name="create_backup">Crear copia de seguridad</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -33,6 +33,7 @@
     <string name="section_appearance">外観</string>
     <string name="section_backup">バックアップ</string>
     <string name="section_about">アプリについて</string>
+    <string name="section_privacy">プライバシー</string>
 
     <!-- Labels and Fields -->
     <string name="your_name">名前</string>
@@ -58,6 +59,10 @@
     <string name="five_days_before">5日前</string>
     <string name="six_days_before">6日前</string>
     <string name="seven_days_before">7日前</string>
+
+    <!-- Privacy -->
+    <string name="prevent_screenshots">スクリーンショットの防止</string>
+    <string name="prevent_screenshots_desc">最近使用したアプリ画面でアプリを非表示にし、スクリーンショットをブロックします</string>
 
     <!-- Backup -->
     <string name="create_backup">バックアップを作成</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="section_appearance">Appearance</string>
     <string name="section_backup">Backup</string>
     <string name="section_about">About</string>
+    <string name="section_privacy">Privacy</string>
 
     <!-- Labels and Fields -->
     <string name="your_name">Your name</string>
@@ -58,6 +59,10 @@
     <string name="five_days_before">5 days before</string>
     <string name="six_days_before">6 days before</string>
     <string name="seven_days_before">7days before</string>
+
+    <!-- Privacy -->
+    <string name="prevent_screenshots">Prevent Screenshots</string>
+    <string name="prevent_screenshots_desc">Hides the app from the recents screen and blocks screenshots</string>
 
     <!-- Backup -->
     <string name="create_backup">Create Backup</string>


### PR DESCRIPTION
This PR adds a privacy section to settings with the option to prevent screenshots on the app and hide the app content from the recent activities view. (fix: #23)